### PR TITLE
Custom domain mappings, API gateway

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@types/node": "^8.0.31",
     "serverless": "^1.23.0",
+    "serverless-domain-manager": "^1.1.12",
     "serverless-offline": "^3.16.0",
     "serverless-plugin-typescript": "^1.1.3"
   }

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,6 +15,7 @@ provider:
 plugins:
   - serverless-plugin-typescript
   - serverless-offline
+  - serverless-domain-manager
 
 package:
   individually: true
@@ -57,3 +58,11 @@ functions:
       - http:
           path: /pptx
           method: post
+
+custom:
+  customDomain:
+    domainName: 'exports.evictionlab.org'
+    certificateName: '*.evictionlab.org'
+    basePath: 'format'
+    stage: ${self:provider.stage}
+    createRoute53Record: true

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@types/node": "^8.0.31",
     "serverless": "^1.23.0",
+    "serverless-domain-manager": "^1.1.12",
     "serverless-offline": "^3.16.0",
     "serverless-plugin-chrome": "^1.0.0-11",
     "serverless-plugin-typescript": "^1.1.3"

--- a/src/serverless.yml
+++ b/src/serverless.yml
@@ -16,6 +16,7 @@ plugins:
   - serverless-plugin-typescript
   - serverless-plugin-chrome
   - serverless-offline
+  - serverless-domain-manager
 
 functions:
   pdf:
@@ -23,5 +24,13 @@ functions:
     handler: pdf/pdf.fileHandler
     events:
       - http:
-          path: /pdf
+          path: /
           method: post
+
+custom:
+  customDomain:
+    domainName: 'exports.evictionlab.org'
+    certificateName: '*.evictionlab.org'
+    basePath: 'pdf'
+    stage: ${self:provider.stage}
+    createRoute53Record: true


### PR DESCRIPTION
This is in the process of being deployed to exports.evictionlab.org, but the base path mappings aren't ideal. To prevent conflicts, AWS doesn't let you have multiple APIs on the same base path (which makes sense), but makes the PDF path stick out. This was my initial stab at it, but let me know if there's an alternate setup you'd prefer (with PDF still having a different base). Here are the paths:

* exports.evictionlab.org/format/docx
* exports.evictionlab.org/format/xlsx
* exports.evictionlab.org/format/pptx
* exports.evictionlab.org/pdf