### PR TITLE
Set Content-Disposition to attachment

### DIFF
--- a/src/exports/export.ts
+++ b/src/exports/export.ts
@@ -59,7 +59,8 @@ export abstract class Export {
             Bucket: this.exportBucket,
             Key: this.key,
             Body: fileBuffer,
-            ACL: 'public-read'
+            ACL: 'public-read',
+            ContentDisposition: 'attachment'
         }).promise();
     }
 }


### PR DESCRIPTION
Using so that all exports can be downloaded with `window.open`