### PR TITLE
Fix CORS, schema properties

### DIFF
--- a/assets/en/report.html
+++ b/assets/en/report.html
@@ -76,7 +76,7 @@ is how [City / county / state]’s eviction rate compares to other
 <p class="western" style="margin-bottom: 0in; line-height: 100%"><br/>
 
 </p>
-<p class="western" style="margin-bottom: 0in; line-height: 100%"><b>{{ features.0.name }}				Eviction
+<p class="western" style="margin-bottom: 0in; line-height: 100%"><b>{{ features.0.properties.n }}				Eviction
 Rate </b>
 </p>
 <p class="western" style="margin-bottom: 0in; line-height: 100%"><br/>
@@ -84,7 +84,7 @@ Rate </b>
 </p>
 <p class="western" style="margin-bottom: 0in; line-height: 100%"><b>{{#each
 features }}</b></p>
-<p class="western" style="margin-bottom: 0in; line-height: 100%">{{name}}						{{er-10}}</p>
+<p class="western" style="margin-bottom: 0in; line-height: 100%">{{properties.n}}						{{properties.er-10}}</p>
 <p class="western" style="margin-bottom: 0in; line-height: 100%">{{/each}}</p>
 <p class="western" style="margin-bottom: 0in; line-height: 100%"><br/>
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -36,6 +36,7 @@ functions:
       - http:
           path: /xlsx
           method: post
+          cors: true
   pptx:
     package:
       include:
@@ -46,6 +47,7 @@ functions:
       - http:
           path: /pptx
           method: post
+          cors: true
   zip:
     package:
       include:
@@ -66,6 +68,7 @@ functions:
       - http:
           path: /zip
           method: post
+          cors: true
 
 custom:
   customDomain:

--- a/src/data/feature.ts
+++ b/src/data/feature.ts
@@ -2,7 +2,7 @@ export interface Feature {
     [index: string]: any;
     properties: {
         GEOID: string;
-        name: string;
+        n: string;
         [index: string]: any;
     }
 }

--- a/src/data/fixture.ts
+++ b/src/data/fixture.ts
@@ -4,21 +4,21 @@ export const FixtureFeatures: Array<Feature> = [
     {
         properties: {
             GEOID: '42',
-            name: 'Pennsylvania',
+            n: 'Pennsylvania',
             'er-10': 10
         }
     },
     {
         properties: {
             GEOID: '36',
-            name: 'New York',
+            n: 'New York',
             'er-10': 11
         }
     },
     {
         properties: {
             GEOID: '17',
-            name: 'Illinois',
+            n: 'Illinois',
             'er-10': 12
         }
     }

--- a/src/exports/handler.ts
+++ b/src/exports/handler.ts
@@ -14,6 +14,7 @@ export async function handler(exportClass, event, context, callback): Promise<vo
 
     callback(null, {
         statusCode: 200,
+        headers: { 'Access-Control-Allow-Origin': "*" },
         body: JSON.stringify({
             path: `https://s3.amazonaws.com/${fileExport.exportBucket}/${fileExport.key}`
         })

--- a/src/exports/pptx.ts
+++ b/src/exports/pptx.ts
@@ -46,7 +46,7 @@ export class PptxExport extends Export {
 
     const titleSlide = this.pptx.addNewSlide({ bkgd: '6B8890' });
 
-    titleSlide.addText(`UNDERSTANDING EVICTION IN ${feature.properties.name}`, {
+    titleSlide.addText(`UNDERSTANDING EVICTION IN ${feature.properties.n}`, {
       align: 'center',
       x: 1.21,
       y: 2.61,
@@ -77,7 +77,7 @@ export class PptxExport extends Export {
     const slideOne = this.pptx.addNewSlide({ bkgd: 'f2f2f2' });
 
     slideOne.addText(
-      `${feature.name} EXPERIENCED [NUMBER] OF EVICTIONS IN [MOST RECENT YEAR]`,
+      `${feature.properties.n} EXPERIENCED [NUMBER] OF EVICTIONS IN [MOST RECENT YEAR]`,
       this.titleParams
     );
 
@@ -92,7 +92,7 @@ export class PptxExport extends Export {
           options: { bullet: true }
         },
         {
-          text: `Below is a graph of estimated eviction rates in ${feature.properties.name} over the last six years`,
+          text: `Below is a graph of estimated eviction rates in ${feature.properties.n} over the last six years`,
           options: { bullet: true }
         }
       ],

--- a/src/serverless.yml
+++ b/src/serverless.yml
@@ -26,6 +26,7 @@ functions:
       - http:
           path: /
           method: post
+          cors: true
 
 custom:
   customDomain:


### PR DESCRIPTION
CORS requests weren't working, and properties eventually need to be expanded to their full names, but for now switching to `n` instead of `name`.