### PR TITLE
Update environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Eviction Lab",
   "license": "MIT",
   "scripts": {
-    "deploy": "aws s3 cp assets s3://eviction-lab-exports/assets --recursive --acl=public-read && sls deploy && cd src && sls deploy",
+    "deploy-dev": "sls deploy --stage dev && cd src && sls deploy --stage dev",
+    "deploy": "aws s3 cp assets s3://eviction-lab-exports/assets --recursive --acl=public-read && sls deploy --stage prod && cd src && sls deploy --stage prod",
     "postinstall": "cd ./node_modules/pptxgenjs && npm install && cd ../.."
   },
   "dependencies": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,7 +16,7 @@ provider:
 plugins:
   - serverless-plugin-typescript
   - serverless-offline
-  - serverless-domain-manager
+  # - serverless-domain-manager
 
 package:
   individually: true
@@ -125,10 +125,10 @@ functions:
           method: post
           cors: true
 
-custom:
-  customDomain:
-    domainName: 'exports.evictionlab.org'
-    certificateName: '*.evictionlab.org'
-    basePath: 'format'
-    stage: ${self:provider.stage}
-    createRoute53Record: true
+# custom:
+#   customDomain:
+#     domainName: 'exports.evictionlab.org'
+#     certificateName: '*.evictionlab.org'
+#     basePath: 'format'
+#     stage: prod
+#     createRoute53Record: true

--- a/src/serverless.yml
+++ b/src/serverless.yml
@@ -16,7 +16,7 @@ plugins:
   - serverless-plugin-typescript
   - serverless-plugin-chrome
   - serverless-offline
-  - serverless-domain-manager
+  # - serverless-domain-manager
 
 functions:
   pdf:
@@ -28,10 +28,10 @@ functions:
           method: post
           cors: true
 
-custom:
-  customDomain:
-    domainName: 'exports.evictionlab.org'
-    certificateName: '*.evictionlab.org'
-    basePath: 'pdf'
-    stage: ${self:provider.stage}
-    createRoute53Record: true
+# custom:
+#   customDomain:
+#     domainName: 'exports.evictionlab.org'
+#     certificateName: '*.evictionlab.org'
+#     basePath: 'pdf'
+#     stage: prod
+#     createRoute53Record: true


### PR DESCRIPTION
Closes #29. Updates build steps, adding `deploy-dev` command for deploying to `exports-dev.evictionlab.org`. Also comments out the domain manager info because it's not needed after the initial creation, and runs into some errors